### PR TITLE
OAuth signature correctly handles spaces which must be percent encoded

### DIFF
--- a/lib/emailage/signature.rb
+++ b/lib/emailage/signature.rb
@@ -5,17 +5,17 @@ require 'base64'
 module Emailage
   module Signature
     class << self
-      
+
       # 9.1.1.  Normalize Request Parameters
       def normalize_query_parameters(params)
-        params.sort.map {|k,v| [CGI.escape(k.to_s), CGI.escape(v.to_s)].join '='}.join '&'
+        params.sort.map {|k,v| [CGI.escape(k.to_s), ERB::Util.url_encode(v.to_s)].join '='}.join '&'
       end
-      
+
       # 9.1.3.  Concatenate Request Elements
       def concatenate_request_elements(method, url, query)
         [method.to_s.upcase, url, query].map {|e| CGI.escape(e)}.join '&'
       end
-      
+
       # 9.2.  HMAC-SHA1
       def hmac_sha1(base_string, hmac_key)
         OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), hmac_key, base_string)
@@ -38,7 +38,7 @@ module Emailage
         # 9.2.1.  Generating Signature
         Base64.strict_encode64 digest
       end
-      
+
     end
   end
 end

--- a/spec/signature_spec.rb
+++ b/spec/signature_spec.rb
@@ -12,27 +12,27 @@ describe Emailage::Signature do
     oauth_nonce: 'kllo9940pd9333jh',
     oauth_version: 1.0,
     file: 'vacation.jpg',
-    size: 'original'
+    size: 'orig inal'
   }}
   let(:hmac_key) {'kd94hf93k423kf44&pfkkdhi9sl3r4s00'}
 
   it 'normalizes query parameters' do
     query = Emailage::Signature.normalize_query_parameters(params)
-    
-    expect(query).to eq 'file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original'
+
+    expect(query).to eq 'file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=orig%20inal'
   end
-  
+
   it 'generates base string' do
     query = Emailage::Signature.normalize_query_parameters(params)
     base_string = Emailage::Signature.concatenate_request_elements(method, url, query)
-    
-    expect(base_string).to eq 'GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal'
+
+    expect(base_string).to eq 'GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Dorig%2520inal'
   end
-  
+
   it 'calculates signature value' do
     signature = Emailage::Signature.create(method, url, params, hmac_key)
-    
-    expect(signature).to eq 'tR3+Ty81lMeYAr/Fid0kMTYa/WM='
+
+    expect(signature).to eq 'NyW8+XlYYrIMfra1Wq/lHf8ru5g='
   end
 
 end


### PR DESCRIPTION
Original implementation encodes special characters such as spaces with `+`. OAuth requires special characters such as spaces be percent encoded ( see example 1 as part of https://oauth.net/core/1.0/#signing_process )