### PR TITLE
Update JSON dependency to address CVE-2020-10663

### DIFF
--- a/emailage.gemspec
+++ b/emailage.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "typhoeus", "~> 1.0"
   spec.add_dependency "uuid", "~> 2.3"
-  spec.add_dependency "json", "~> 2.1"
+  spec.add_dependency "json", "~> 2.3"
 end


### PR DESCRIPTION
Updating JSON dependency to address https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10663