### PR TITLE
raise temporary error if blank response and not 200

### DIFF
--- a/emailage.gemspec
+++ b/emailage.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redcarpet", "~> 3.3"
 
   spec.add_dependency "typhoeus", "~> 1.0"
-  spec.add_dependency "uuid", "~> 2.3"
   spec.add_dependency "json", "~> 2.3"
 end

--- a/lib/emailage/client.rb
+++ b/lib/emailage/client.rb
@@ -1,5 +1,5 @@
 require 'typhoeus'
-require 'uuid'
+require 'securerandom'
 require 'json'
 
 module Emailage
@@ -38,7 +38,7 @@ module Emailage
       params = {
         :format => 'json', 
         :oauth_consumer_key => @secret,
-        :oauth_nonce => UUID.new.generate,
+        :oauth_nonce => SecureRandom.uuid,
         :oauth_signature_method => 'HMAC-SHA1',
         :oauth_timestamp => Time.now.to_i,
         :oauth_version => 1.0

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,9 +4,10 @@ describe Emailage::Client do
   let(:t) {spy :typhoeus}
   let(:email) {'test+emailage@example.com'}
   let(:ip) {'1.234.56.7'}
-  
+  let(:response) { double :response, :body => "\xEF\xBB\xBF{\"success\":[true]}", :code => 200 }
+
   before {
-    allow(t).to receive(:get) {double :response, :body => "\xEF\xBB\xBF{\"success\":[true]}"}
+    allow(t).to receive(:get) { response }
     stub_const 'Typhoeus', t
   }
   
@@ -32,6 +33,14 @@ describe Emailage::Client do
   
     it 'parses response body as JSON' do
       expect(request).to eq 'success' => [true]
+    end
+
+    context 'empty string returned' do
+      let(:response) { double :response, :body => "", :code => 503 }
+
+      it 'raises TemporaryError' do
+        expect { request }.to raise_error(described_class::TemporaryError)
+      end
     end
   end
 


### PR DESCRIPTION
so we can catch the exception in any code that calls this and handle appropriately