### PR TITLE
Switch from uuid gem to SecureRandom.uuid

### DIFF
--- a/emailage.gemspec
+++ b/emailage.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redcarpet", "~> 3.6"
 
   spec.add_dependency "typhoeus", "~> 1.4"
-  spec.add_dependency "uuid", "~> 2.3"
   spec.add_dependency "json", "~> 2.9"
 end


### PR DESCRIPTION
The uuid gem is no longer actively maintained and now emits this warning in newer verison of ruby:
```
/usr/local/bundle/ruby/3.4.0/gems/uuid-2.3.9/uuid.gemspec:19: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

This PR removes the gem and just uses Ruby's `SecureRandom.uuid` function. It's been supported since Ruby 2.5. 